### PR TITLE
Fix Ruby syntax error in keyword arguments for Ruby <= 3.0

### DIFF
--- a/lib/toon.rb
+++ b/lib/toon.rb
@@ -20,11 +20,11 @@ module Toon
   # @return [nil] if writing to output
   def encode(input, indent: 2, delimiter: DEFAULT_DELIMITER, length_marker: false, output: nil)
     normalized_value = Normalizer.normalize_value(input)
-    options = resolve_options(indent: indent, delimiter: delimiter, length_marker: length_marker, output:)
+    options = resolve_options(indent: indent, delimiter: delimiter, length_marker: length_marker, output: output)
     Encoders.encode_value(normalized_value, options)
   end
 
-  def resolve_options(indent:, delimiter:, length_marker:, output:)
+  def resolve_options(indent:, delimiter:, length_marker:, output: nil)
     {
       indent: indent,
       delimiter: delimiter,

--- a/spec/toon_spec.rb
+++ b/spec/toon_spec.rb
@@ -779,7 +779,7 @@ RSpec.describe Toon do
 
     it 'can encode lines to IO interface object' do
       output = StringIO.new
-      expect(Toon.encode(obj, output:)).to be_nil
+      expect(Toon.encode(obj, output: output)).to be_nil
       expect(output.string).to eq "hello: 世界"
     end
 


### PR DESCRIPTION
- Addresses compatibility issue with Ruby versions **<= 3.0** where this syntax was invalid
- Fixed syntax error where `output:` was used without value